### PR TITLE
Allow Close() to cancel ZeroCopyReadPacketData

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -144,7 +144,6 @@ type TPacket struct {
 
 	// stores the pipe FDs used to cancel polling
 	exitPipeFds []int
-	exit        chan struct{}
 	once        sync.Once
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR allows Close() to cancel ZeroCopyReadPacketData. It adds a pipe FD to the poll logic and uses that to trigger a cancellation of the poll.

### Motivation
Improves performance of the agent network tracer test suite, especially for ebpfless.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Using the agent PR here: https://github.com/DataDog/datadog-agent/pull/33056

Existing test suite should pass, and run 24% faster, `577.173s` -> `466.346s` (because it incidentally speeds up the DNS snooper):
```
DD_REMOTE_CONFIGURATION_ENABLED=false sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite
```
Ebpfless test suite should pass, and run 3x faster, `69.357s` -> `22.789s`:
```
DD_REMOTE_CONFIGURATION_ENABLED=false TEST_EBPFLESS_OVERRIDE=true sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite/eBPFless
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->